### PR TITLE
Stretch request timeout in line with retry timeout

### DIFF
--- a/lib/Fetcher.js
+++ b/lib/Fetcher.js
@@ -14,7 +14,7 @@ function Fetcher(config) {
         api_key: config.apiKey
     };
     requestOptions = {
-        timeout: 1000
+        timeout: 5000
     };
     retryOptions = {
         retries: 3,
@@ -49,6 +49,7 @@ Fetcher.prototype._request = function (feedName, params) {
     var defer = Q.defer(),
         that = this,
         operation = retry.operation(retryOptions),
+        timeouts = retry.timeouts(retryOptions),
         params = u.extend({}, this.defaultRequestParams, params),
         url = this.config.iblUrl + feedName + '.json?' + qs.stringify(params),
         requestOptions = u.extend({}, this.requestOptions, {url:url});
@@ -57,6 +58,8 @@ Fetcher.prototype._request = function (feedName, params) {
 
     if (cached === false) {
         operation.attempt(function(currentAttempt) {
+            requestOptions.timeout = timeouts[currentAttempt-1];
+
             that.request(requestOptions, function (err, response, body) {
                 if (operation.retry(err)) {
                     console.log("[INFO] Retrying ", feedName);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixturator",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This means that the retries will use an incremental strategy for request timeouts as well as time between retries. This ends up as the following:

Old Behaviour:

```
Request  1: 1000
Delay  1: 2000
Request  2: 1000
Delay  2: 3000
Request  3: 1000

Max: 9000
```

New Behaviour:

```
Request  1: 2000
Delay  1: 2000
Request  2: 3000
Delay  2: 3000
Request  3: 4500

Max: 14500
```
