### PR TITLE
Update `findElementsArray` for programmes

### DIFF
--- a/lib/Fixture.js
+++ b/lib/Fixture.js
@@ -140,51 +140,51 @@ Fixture.findElementsArray = function (feed) {
         return feed.elements;
 
     if (feed.episodes !== undefined)
-        return feed.episodes;
-
-    if (feed.home_highlights !== undefined)
-        elementsArray = feed.home_highlights;
-
-    if (feed.tv_highlights !== undefined)
-        elementsArray = feed.tv_highlights;
-
-    if (feed.highlights !== undefined)
-        elementsArray = feed.highlights;
-
-    if (feed.channel_highlights !== undefined)
-        elementsArray = feed.channel_highlights;
-
-    if (feed.programme_episodes !== undefined)
-        elementsArray = feed.programme_episodes;
-
-    if (feed.category_highlights !== undefined)
-        elementsArray = feed.category_highlights;
+        elementsArray = feed.episodes;
 
     if (feed.programmes !== undefined)
         elementsArray = feed.programmes;
 
+    if (feed.home_highlights !== undefined)
+        elementsArray = feed.home_highlights.elements;
+
+    if (feed.tv_highlights !== undefined)
+        elementsArray = feed.tv_highlights.elements;
+
+    if (feed.highlights !== undefined)
+        elementsArray = feed.highlights.elements;
+
+    if (feed.channel_highlights !== undefined)
+        elementsArray = feed.channel_highlights.elements;
+
+    if (feed.programme_episodes !== undefined)
+        elementsArray = feed.programme_episodes.elements;
+
+    if (feed.category_highlights !== undefined)
+        elementsArray = feed.category_highlights.elements;
+
     if (feed.category_programmes !== undefined)
-        elementsArray = feed.category_programmes;
+        elementsArray = feed.category_programmes.elements;
 
     if (feed.atoz_programmes !== undefined)
-        elementsArray = feed.atoz_programmes;
+        elementsArray = feed.atoz_programmes.elements;
 
     if (feed.group_episodes !== undefined)
-        elementsArray = feed.group_episodes;
+        elementsArray = feed.group_episodes.elements;
 
     if (feed.episode_recommendations !== undefined)
-        elementsArray = feed.episode_recommendations;
+        elementsArray = feed.episode_recommendations.elements;
 
     if (feed.broadcasts !== undefined)
-        elementsArray = feed.broadcasts;
+        elementsArray = feed.broadcasts.elements;
 
     if (feed.schedule !== undefined)
-        elementsArray = feed.schedule;
+        elementsArray = feed.schedule.elements;
 
     if (elementsArray === undefined)
         return false;
 
-    return elementsArray.elements;
+    return elementsArray;
 };
 
 Fixture.typeToClass = function (type) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixturator",
-  "version": "0.1.12",
+  "version": "0.1.17",
   "description": "",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Updated method to return `feed.programmes`, rather than `feed.programmes.elements` as the programmes feed does include an elements object
