### PR TITLE
No more timestamp = no more cache and we never knew

### DIFF
--- a/lib/Fetcher.js
+++ b/lib/Fetcher.js
@@ -3,6 +3,7 @@ var requestLib = require('request'),
     u = require('underscore'),
     Q = require('q'),
     fs = require('fs'),
+    path = require('path'),
     retry = require('retry');
 
 function Fetcher(config) {
@@ -109,9 +110,12 @@ Fetcher.prototype.getFromCache = function(feedName, params) {
 
     // Anything that goes wrong here can just be treated as a cache MISS
     try {
-        feed = fs.readFileSync(this.config.cacheDir + fileName, {encoding: 'utf-8'});
+        var feedPath = path.resolve(this.config.cacheDir + fileName),
+            feed = fs.readFileSync(feedPath, {encoding: 'utf-8'}),
+            stat = fs.statSync(feedPath);
+
         feed = JSON.parse(feed);
-        created = new Date(feed.timestamp);
+        created = new Date(stat.mtime);
         if (created.getTime() > this.config.cacheExpireTime) {
             // console.log('CACHE HIT!')
             return feed;


### PR DESCRIPTION
So this is awkward, but the lack of a .timestamp means that fixturator hasn't been caching for awhile now.