### PR TITLE
Add purchases to elements arrays

### DIFF
--- a/lib/Fixture.js
+++ b/lib/Fixture.js
@@ -187,6 +187,9 @@ Fixture.findElementsArray = function (feed) {
     if (feed.compilation_groups !== undefined)
         elementsArray = feed.compilation_groups.elements;
 
+    if (feed.purchases !== undefined)
+        elementsArray = feed.purchases.elements;
+
     if (elementsArray === undefined)
         return false;
 


### PR DESCRIPTION
As per the example feed in https://confluence.dev.bbc.co.uk/pages/viewpage.action?pageId=102973593

Confirmed with @andycharris that "purchases" is going to be the main element for sure in the final feeds.