### PR TITLE
Adds check for titles property

### DIFF
--- a/lib/Elements/BaseElement.js
+++ b/lib/Elements/BaseElement.js
@@ -13,7 +13,9 @@ BaseElement.prototype.setMasterbrand = function (id, name) {
     }
 
     if (!this.data.master_brand) {
-        this.data.master_brand = {};
+        this.data.master_brand = {
+            titles: {}
+        };
     }
 
     this.data.master_brand.id = id;


### PR DESCRIPTION
It seems sometimes the masterbrand wasn't present so the following code was executed:

```
if (!this.data.master_brand) {
        this.data.master_brand = {};
    }
```

This doesn't set the `titles` property though, which means referencing `master_brand.titles.small` breaks. 

It's an intermittent failure, but I've run the grunt job many times and it doesn't seem to break anymore